### PR TITLE
python3-improv: fix missing claim token on Wi-Fi success

### DIFF
--- a/recipes-devtools/python/python3-improv/imx8mm-jaguar-inst/onboarding-server.py
+++ b/recipes-devtools/python/python3-improv/imx8mm-jaguar-inst/onboarding-server.py
@@ -198,7 +198,14 @@ def wifi_connect(ssid: str, passwd: str) -> Optional[list[str]]:
     server = f"https://{SERVER_HOST}?ip_address={ip_addr}&token={token}"
     return [server]
 
-improv_server = ImprovProtocol(wifi_connect_callback=wifi_connect)
+# Improv chunks its RPC response into <= max_response_bytes packets. The library
+# default (100) can be below the Wi-Fi-success redirect URL length (host + UUID
+# token), which trips a pyImprov bug: it emits a spurious zero-length
+# WIFI_SETTINGS packet *before* the packet carrying the URL. Clients that
+# complete on the first result then never see the token. Raise the threshold so
+# the URL is returned in a single packet (within the BLE MTU the app negotiates).
+improv_server = ImprovProtocol(wifi_connect_callback=wifi_connect,
+                               max_response_bytes=200)
 
 def read_request(
         characteristic: BlessGATTCharacteristic,

--- a/recipes-devtools/python/python3-improv/imx93-jaguar-eink/onboarding-server.py
+++ b/recipes-devtools/python/python3-improv/imx93-jaguar-eink/onboarding-server.py
@@ -485,7 +485,16 @@ def wifi_connect(ssid: str, passwd: str) -> Optional[list[str]]:
     server = f"https://{SERVER_HOST}?ip_address={ip_addr}&token={token}"
     return [server]
 
-improv_server = ImprovProtocol(wifi_connect_callback=wifi_connect)
+# Improv chunks its RPC response into <= max_response_bytes packets. The library
+# default (100) is *below* our Wi-Fi-success redirect URL length (~117 B: the
+# active-esl-onboard.active-esl.workers.dev host + a UUID token), which trips a
+# pyImprov bug: it emits a spurious zero-length WIFI_SETTINGS packet *before* the
+# packet carrying the URL. Clients that complete on the first result then never
+# see the token ("connected to Wi-Fi but no claim token"). Raise the threshold so
+# the URL is returned in a single packet (~121 B, well within the ~185 B BLE MTU
+# the app negotiates).
+improv_server = ImprovProtocol(wifi_connect_callback=wifi_connect,
+                               max_response_bytes=200)
 
 def read_request(characteristic: BlessGATTCharacteristic, **kwargs) -> bytearray:
     try:

--- a/recipes-devtools/python/python3-improv/onboarding-server.py
+++ b/recipes-devtools/python/python3-improv/onboarding-server.py
@@ -236,7 +236,14 @@ def wifi_connect(ssid: str, passwd: str) -> Optional[list[str]]:
     server = f"https://{SERVER_HOST}?ip_address={ip_addr}&token={token}"
     return [server]
 
-improv_server = ImprovProtocol(wifi_connect_callback=wifi_connect)
+# Improv chunks its RPC response into <= max_response_bytes packets. The library
+# default (100) can be below the Wi-Fi-success redirect URL length (host + UUID
+# token), which trips a pyImprov bug: it emits a spurious zero-length
+# WIFI_SETTINGS packet *before* the packet carrying the URL. Clients that
+# complete on the first result then never see the token. Raise the threshold so
+# the URL is returned in a single packet (within the BLE MTU the app negotiates).
+improv_server = ImprovProtocol(wifi_connect_callback=wifi_connect,
+                               max_response_bytes=200)
 
 def read_request(
         characteristic: BlessGATTCharacteristic,


### PR DESCRIPTION
## Summary
- Fixes the app-reported error **"connected to Wi-Fi but did not return a claim token"** at its source in the firmware.
- Root cause: pyImprov's `build_rpc_response` chunks the RPC response at `max_response_bytes` (default **100**). Our Wi-Fi-success redirect URL is ~117 B (`active-esl-onboard.active-esl.workers.dev?...&token=<uuid>`), so it exceeds the threshold and pyImprov emits a **spurious zero-length `WIFI_SETTINGS` packet before** the packet that actually carries the URL. Clients that complete on the first (empty) result never see the token.
- Fix: construct `ImprovProtocol(..., max_response_bytes=200)` on all three board variants (`imx93-jaguar-eink`, `imx8mm-jaguar-inst`, default). The URL now returns in a single ~121 B packet — no split, no leading empty packet — comfortably within the ~185 B BLE MTU the app negotiates.

## Notes
- Independent of, and complementary to, the app/CLI change that already tolerates the empty-then-URL sequence defensively (belt-and-braces).
- No functional change to the advertised URL or token; only the BLE response chunking threshold.

## Test plan
- [ ] Flash an eink build with this change; onboard via the app and confirm a claim token is received on the first attempt.
- [ ] Verify the `WIFI_SETTINGS` result arrives as a single packet (no leading empty packet) via the `improv-provision` CLI smoke test.

Made with [Cursor](https://cursor.com)