### PR TITLE
ci: pin KAS validate/summary jobs to Linux self-hosted runner

### DIFF
--- a/.github/workflows/kas-build-ci.yml
+++ b/.github/workflows/kas-build-ci.yml
@@ -46,7 +46,10 @@ jobs:
   # Validation job - validates Yocto layer compatibility
   validate:
     name: Validate Yocto Layers
-    runs-on: self-hosted
+    # Pin to a Linux self-hosted runner: bare `self-hosted` also matches the
+    # org's macOS runners, which have no Docker and fail this container job
+    # in ~6s with "docker: command not found".
+    runs-on: [self-hosted, Linux, X64]
     container:
       image: dynamicdevices/yocto-ci-build:latest
       options: --privileged --platform linux/amd64
@@ -167,7 +170,7 @@ jobs:
   # Summary job
   summary:
     name: Validation Summary
-    runs-on: self-hosted
+    runs-on: [self-hosted, Linux, X64]
     needs: [validate]
     if: always()
     


### PR DESCRIPTION
## Summary
- The `Validate Yocto Layers` (and `Validation Summary`) jobs use bare `runs-on: self-hosted`, which matches **any** org self-hosted runner — including the macOS Hackintosh runners (`proxmox-macos-tahoe`, `macmini-2014-xcode`).
- When the container-based `validate` job (image `dynamicdevices/yocto-ci-build:latest`, `--platform linux/amd64`) is scheduled on a macOS runner it fails in ~6s with `docker: command not found`, leaving a persistent red check on every PR (seen on #38, #40, #41).
- Pin both jobs to `[self-hosted, Linux, X64]` so they only run on the Linux runner (`github-runner`), which has Docker.

## Test plan
- [ ] This PR's own `KAS Build CI` run schedules `Validate Yocto Layers` on the Linux runner (not macOS) and the Docker container starts.
- [ ] `Validation Summary` runs and passes.

Made with [Cursor](https://cursor.com)